### PR TITLE
FIX: Adjust the order when little-endian is used.

### DIFF
--- a/ip330App/src/drvIp330.c
+++ b/ip330App/src/drvIp330.c
@@ -165,11 +165,21 @@ static void rebootCallback(void *drvPvt);
 
 typedef struct ip330ADCregs {
     unsigned short control;
+#if BYTE_ORDER==__BIG_ENDIAN
     unsigned char timePrescale;
     unsigned char intVector;
+#else
+    unsigned char intVector;
+    unsigned char timePrescale;
+#endif
     unsigned short conversionTime;
+#if BYTE_ORDER==__BIG_ENDIAN
     unsigned char endChanVal;
     unsigned char startChanVal;
+#else
+    unsigned char startChanVal;
+    unsigned char endChanVal;
+#endif
     unsigned short newData[2];
     unsigned short missedData[2];
     unsigned short startConvert;


### PR DESCRIPTION
This patch was hanging here at SLAC and looks like it was never send back.
This fixes the case where little-endian is used (in our case ~~PowerPC~~ CPU with Intel).